### PR TITLE
Throw proper error messages

### DIFF
--- a/lib/connect-session-file.js
+++ b/lib/connect-session-file.js
@@ -19,10 +19,10 @@ var FileSessionStore = module.exports = function FileSessionStore(opts) {
 
     // define default session store directory
     this.prefix = opts.prefix || 'file-store-';
-    this.path = process.env.TMPDIR || process.env.TEMP;
-    // ensure specified path exists (create if neccesary)
-    if( opts.path && fs.existsSync(opts.path) ){
-        this.path = opts.path;
+    this.path = opts.path || process.env.TMPDIR || process.env.TEMP;
+    // ensure specified path exists
+    if (!fs.existsSync(this.path)) {
+        throw new Error('Path ' + this.path + ' does not exist!');
     }
     this.useAsync = opts.useAsync;
     this.printDebug = opts.printDebug;


### PR DESCRIPTION
Formerly this error was thrown when the path doesn't exist:

path.js:360
        throw new TypeError('Arguments to path.join must be strings');
              ^
TypeError: Arguments to path.join must be strings
    at path.js:360:15
    at Array.filter (native)
    at Object.exports.join (path.js:358:36)
    at FileSessionStore.set (/home/mop/public_html/rrr/node_modules/connect-session-file/lib/connect-session-file.js:151:25)
    at Session.save (/home/mop/public_html/rrr/node_modules/express/node_modules/connect/lib/middleware/session/session.js:63:25)

That's not really helpful ;)
