### PR TITLE
Use "/tmp" if TMPDIR or TEMP is unavailable

### DIFF
--- a/lib/connect-session-file.js
+++ b/lib/connect-session-file.js
@@ -19,7 +19,7 @@ var FileSessionStore = module.exports = function FileSessionStore(opts) {
 
     // define default session store directory
     this.prefix = opts.prefix || 'file-store-';
-    this.path = opts.path || process.env.TMPDIR || process.env.TEMP;
+    this.path = opts.path || process.env.TMPDIR || process.env.TEMP || '/tmp';
     // ensure specified path exists
     if (!fs.existsSync(this.path)) {
         throw new Error('Path ' + this.path + ' does not exist!');


### PR DESCRIPTION
Some distos don't set either of the two variables, as I just experienced. 
