### PR TITLE
Use peer connect/express module

### DIFF
--- a/lib/connect-session-file.js
+++ b/lib/connect-session-file.js
@@ -5,7 +5,16 @@ var path = require('path'),
     util = require('util'),
     fs = require('fs'),
     crypto = require('crypto'),
-    Store = require('connect').middleware.session.Store;
+    connect,
+    Store
+
+try {
+    connect = require('connect');
+} catch (e) {
+    connect = require('express/node_modules/connect');
+} finally {
+    Store = connect.middleware.session.Store;
+}
 
 /**
    Initialize FileSessionStore with given `opts`.

--- a/package.json
+++ b/package.json
@@ -17,9 +17,6 @@
     "lib" : "lib"
   },
   "main": "./lib/connect-session-file",
-  "dependencies": {
-    "connect": ">=2.7.3"
-  },
   "repository": {
     "type":"git",
     "url":"http://github.com/odogono/connect-session-file.git"


### PR DESCRIPTION
The `connect` version used by this middleware should be the same as that used by the application itself. This patch uses an installed `connect` or `express` instance instead of it's own copy. `peerDependencies` can't be used in package.json since these would be optional.

Alternatives are 
1. setting `peerDependencies: { connect: ... }` and publishing a separate `express-session-file` that peer-depends on `express`
2. use dependency injection, eg `FileStore = require('connect-session-file')(connect)` - clumsy when using express since it doesn't expose it's connect dependency: `require('connect-session-file')(require('express/node_modules/connect'))`
