### PR TITLE
Doesn't currently work with connect 3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "main": "./lib/connect-session-file",
   "dependencies": {
-    "connect": ">=2.7.3"
+    "connect": ">=2.7.3 < 3.0.0"
   },
   "repository": {
     "type":"git",


### PR DESCRIPTION
```
Cannot read property 'session' of undefined

{ column: 42,
       file: '~/code/location/node_modules/connect-session-file/lib/connect-session-file.js',
       function: '',
       line: 9,
       method: null,
       native: false }
```

Fixing the require statement would be the better option probably but as a quick fix this should work out.
